### PR TITLE
Named generics

### DIFF
--- a/compiler/src/main/kotlin/deezer/kustom/compiler/ExportCompiler.kt
+++ b/compiler/src/main/kotlin/deezer/kustom/compiler/ExportCompiler.kt
@@ -112,7 +112,7 @@ class ExportCompiler(private val environment: SymbolProcessorEnvironment) : Symb
                 // Pick the first arguments matching 'exportGenerics' and flatmap all entries
                 .flatMap { it.getArg<List<KSAnnotation>>(KustomExportGenerics::exportGenerics) }
                 .forEach { generics ->
-                    val name = generics.getArg<String>(KustomGenerics::name)
+                    val name = generics.getArg<String?>(KustomGenerics::name)
                     val kClass = generics.getArg<KSType>(KustomGenerics::kClass)
                     val typeParameters = generics.getArg<List<KSType>>(KustomGenerics::typeParameters)
 
@@ -134,7 +134,7 @@ class ExportCompiler(private val environment: SymbolProcessorEnvironment) : Symb
                     parseAndWrite(
                         targetClassDeclaration,
                         targetTypeNames,
-                        overrideClassSimpleName = name.ifBlank { targetClassDeclaration.simpleName.asString() },
+                        overrideClassSimpleName = if (name?.isNotBlank() == true) name else targetClassDeclaration.simpleName.asString(),
                         sources = sources
                     )
 

--- a/compiler/src/main/kotlin/deezer/kustom/compiler/ExportCompiler.kt
+++ b/compiler/src/main/kotlin/deezer/kustom/compiler/ExportCompiler.kt
@@ -66,23 +66,28 @@ class ExportCompiler(private val environment: SymbolProcessorEnvironment) : Symb
     override fun process(resolver: Resolver): List<KSAnnotated> {
         CompilerArgs.erasePackage = environment.options["erasePackage"] == "true"
 
+        // prepare generics resolution before generating all classes
+        val genericsVisitor = GenericsVisitor(resolver)
+        val genericsAnnotated = resolver.getSymbolsWithAnnotation(KustomExportGenerics::class.qualifiedName!!)
+        genericsAnnotated.forEach { it.accept(genericsVisitor, Unit) }
+
         val annotations = listOf(
             KustomExport::class,
             KustomExportGenerics::class
         )
 
-        annotations.flatMap {
-            resolver.getSymbolsWithAnnotation(
-                annotationName = it.qualifiedName!!,
-                inDepth = true
-            )
-        }
+        val exportVisitor = ExportVisitor(resolver)
+        resolver.getSymbolsWithAnnotation(
+            annotationName = KustomExport::class.qualifiedName!!,
+            inDepth = true
+        )
             //.filter { it is KSClassDeclaration || it is KSTypeAlias /*&& it.validate()*/ }
             .forEach {
-                devLog("----- Symbol $it")
-                it.accept(ExportVisitor(resolver), Unit)
+                it.accept(exportVisitor, Unit)
                 //it.accept(LoggerVisitor(environment), Unit)
             }
+
+        genericsAnnotated.forEach { it.accept(exportVisitor, Unit) }
 
         /*return symbols.filter { !it.validate() }.toList()
             .also { list ->
@@ -105,18 +110,11 @@ class ExportCompiler(private val environment: SymbolProcessorEnvironment) : Symb
                 // Get only the KustomExportGenerics one
                 .filter { it.annotationType.resolve().declaration.qualifiedName?.asString() == KustomExportGenerics::class.qualifiedName }
                 // Pick the first arguments matching 'exportGenerics' and flatmap all entries
-                .flatMap { it.arguments.first { it.name?.asString() == KustomExportGenerics::exportGenerics.name }.value as List<KSAnnotation> }
+                .flatMap { it.getArg<List<KSAnnotation>>(KustomExportGenerics::exportGenerics) }
                 .forEach { generics ->
-//file.annotations.toList()[0].arguments[0].value
-                    val name =
-                        generics.arguments.firstOrNull { it.name?.asString() == KustomGenerics::name.name }?.value as? String
-                    val kClass =
-                        generics.arguments.firstOrNull { it.name?.asString() == KustomGenerics::kClass.name }?.value as? KSType
-                    val typeParameters = generics.arguments
-                        .first { it.name?.asString() == KustomGenerics::typeParameters.name }
-                        .value as List<KSType>
-
-                    if (kClass == null) return@forEach
+                    val name = generics.getArg<String>(KustomGenerics::name)
+                    val kClass = generics.getArg<KSType>(KustomGenerics::kClass)
+                    val typeParameters = generics.getArg<List<KSType>>(KustomGenerics::typeParameters)
 
                     val targetClassDeclaration = kClass.declaration as KSClassDeclaration
                     val targetTypeParameters = targetClassDeclaration.typeParameters
@@ -133,7 +131,12 @@ class ExportCompiler(private val environment: SymbolProcessorEnvironment) : Symb
                     } else {
                         arrayOf(file, targetClassDeclaration.containingFile!!)
                     }
-                    parseAndWrite(targetClassDeclaration, targetTypeNames, *sources)
+                    parseAndWrite(
+                        targetClassDeclaration,
+                        targetTypeNames,
+                        overrideClassSimpleName = name.ifBlank { targetClassDeclaration.simpleName.asString() },
+                        sources = sources
+                    )
 
                     /*
                     val qualifiedName = gen.kClass.qualifiedName
@@ -173,10 +176,11 @@ class ExportCompiler(private val environment: SymbolProcessorEnvironment) : Symb
         private fun parseAndWrite(
             classDeclaration: KSClassDeclaration,
             targetTypeNames: List<Pair<String, ClassName>>,
+            overrideClassSimpleName: String = classDeclaration.simpleName.asString(),
             vararg sources: KSFile
         ) {
             val allSources = if (sources.isNotEmpty()) sources else arrayOf(classDeclaration.containingFile!!)
-            when (val descriptor = parseClass(classDeclaration, targetTypeNames)) {
+            when (val descriptor = parseClass(classDeclaration, targetTypeNames, overrideClassSimpleName)) {
                 is ClassDescriptor -> descriptor.transform()
                     .writeCode(environment, *allSources)
                 is SealedClassDescriptor -> descriptor.transform()

--- a/compiler/src/main/kotlin/deezer/kustom/compiler/GenericsVisitor.kt
+++ b/compiler/src/main/kotlin/deezer/kustom/compiler/GenericsVisitor.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 Deezer.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package deezer.kustom.compiler
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSVisitorVoid
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.ksp.KotlinPoetKspPreview
+import com.squareup.kotlinpoet.ksp.toClassName
+import deezer.kustom.KustomExportGenerics
+import deezer.kustom.KustomGenerics
+
+data class Generics(val exportName: String, val originType: ClassName, val typeParameters: List<ClassName>)
+
+@KotlinPoetKspPreview
+class GenericsVisitor(val resolver: Resolver) : KSVisitorVoid() {
+    companion object {
+        // Generics interface/class can generate wrappers if the type is "resolved" to a type (interface or class).
+        // 1 generic can generate multiple wrappers, for example List<T> -> List<Int>, List<Float>
+        // This map collects all resolutions for this build/compilation module (understand gradle module).
+        val resolvedGenerics = mutableListOf<Generics>()
+    }
+
+    override fun visitFile(file: KSFile, data: Unit) {
+        file.annotations// All file annotations
+            // Get only the KustomExportGenerics one
+            .filter { it.annotationType.resolve().declaration.qualifiedName?.asString() == KustomExportGenerics::class.qualifiedName }
+            // Pick the first arguments matching 'exportGenerics' and flatmap all entries
+            .flatMap {
+                it.arguments
+                    .first { arg -> arg.name?.asString() == KustomExportGenerics::exportGenerics.name }
+                    .value as List<KSAnnotation>
+            }
+            .forEach { generics ->
+                val name = generics.getArg<String>(KustomGenerics::name)
+                val kClass = generics.getArg<KSType>(KustomGenerics::kClass).toClassName()
+                val typeParameters = generics.getArg<List<KSType>>(KustomGenerics::typeParameters).map { it.toClassName() }
+                resolvedGenerics.add(Generics(name, kClass, typeParameters))
+            }
+    }
+
+    /*
+    override fun visitTypeAlias(typeAlias: KSTypeAlias, data: Unit) {
+        val target = (typeAlias.type.element?.parent as? KSTypeReference)?.resolve() ?: return
+        // targetClassDeclaration is templated
+        val targetClassDeclaration = target.declaration as? KSClassDeclaration ?: return
+
+        // Contains "Template" list
+        val targetTypeParameters = targetClassDeclaration.typeParameters
+        val targetTypeNames = typeAlias.type.element?.typeArguments
+            ?.map { it.type!!.resolve().toClassName() }
+            ?.mapIndexed { index, className -> targetTypeParameters[index].name.asString() to className }
+            ?: return
+    }*/
+}

--- a/compiler/src/main/kotlin/deezer/kustom/compiler/GenericsVisitor.kt
+++ b/compiler/src/main/kotlin/deezer/kustom/compiler/GenericsVisitor.kt
@@ -50,9 +50,9 @@ class GenericsVisitor(val resolver: Resolver) : KSVisitorVoid() {
                     .value as List<KSAnnotation>
             }
             .forEach { generics ->
-                val name = generics.getArg<String>(KustomGenerics::name)
                 val kClass = generics.getArg<KSType>(KustomGenerics::kClass).toClassName()
                 val typeParameters = generics.getArg<List<KSType>>(KustomGenerics::typeParameters).map { it.toClassName() }
+                val name = generics.getArg<String?>(KustomGenerics::name) ?: kClass.simpleName
                 resolvedGenerics.add(Generics(name, kClass, typeParameters))
             }
     }

--- a/compiler/src/main/kotlin/deezer/kustom/compiler/KspExt.kt
+++ b/compiler/src/main/kotlin/deezer/kustom/compiler/KspExt.kt
@@ -19,11 +19,13 @@ package deezer.kustom.compiler
 
 import com.google.devtools.ksp.processing.Dependencies
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSFile
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.TypeName
 import java.io.OutputStream
+import kotlin.reflect.KProperty1
 
 fun FileSpec.writeCode(environment: SymbolProcessorEnvironment, vararg sources: KSFile) {
     environment.codeGenerator.createNewFile(
@@ -44,3 +46,7 @@ fun OutputStream.appendText(str: String) {
 
 fun TypeName.firstParameterizedType() = (this as ParameterizedTypeName).typeArguments.first()
 fun TypeName.secondParameterizedType() = (this as ParameterizedTypeName).typeArguments[1]
+
+@Suppress("UNCHECKED")
+fun <T> KSAnnotation.getArg(kProp: KProperty1<*, *>) =
+    arguments.first { it.name?.asString() == kProp.name }.value as T

--- a/compiler/src/main/kotlin/deezer/kustom/compiler/js/FormatString.kt
+++ b/compiler/src/main/kotlin/deezer/kustom/compiler/js/FormatString.kt
@@ -42,6 +42,5 @@ class FormatString(val format: String, vararg args: Any?) {
 }
 
 fun String.eq(formatString: FormatString) = formatString.argsArray.isEmpty() && formatString.format == this
-operator fun String.plus(other: FormatString) = FormatString(this) + other
 
 fun String.toFormatString(vararg args: Any?) = FormatString(this, *args)

--- a/compiler/src/main/kotlin/deezer/kustom/compiler/js/MethodNameDisambiguation.kt
+++ b/compiler/src/main/kotlin/deezer/kustom/compiler/js/MethodNameDisambiguation.kt
@@ -39,6 +39,11 @@ class MethodNameDisambiguation {
             return newName
         }
 
-        TODO()
+        var poorName = origin.name
+        while (generatedNames.containsValue(poorName)) {
+            poorName += "_"
+        }
+        generatedNames[origin] = poorName
+        return poorName
     }
 }

--- a/compiler/src/main/kotlin/deezer/kustom/compiler/js/Structs.kt
+++ b/compiler/src/main/kotlin/deezer/kustom/compiler/js/Structs.kt
@@ -105,6 +105,7 @@ data class ClassDescriptor(
     val classSimpleName: String,
     val exportedClassSimpleName: String,
     val isOpen: Boolean,
+    val isObject: Boolean,
     val isThrowable: Boolean,
     val concreteTypeParameters: List<TypeParameterDescriptor>,
     val supers: List<SuperDescriptor>,

--- a/compiler/src/main/kotlin/deezer/kustom/compiler/js/Structs.kt
+++ b/compiler/src/main/kotlin/deezer/kustom/compiler/js/Structs.kt
@@ -65,6 +65,7 @@ sealed class Descriptor
 data class InterfaceDescriptor(
     val packageName: String,
     val classSimpleName: String,
+    val exportedClassSimpleName: String,
     val concreteTypeParameters: List<TypeParameterDescriptor>,
     val supers: List<SuperDescriptor>,
     val properties: List<PropertyDescriptor>,
@@ -102,6 +103,7 @@ data class SealedSubClassDescriptor(
 data class ClassDescriptor(
     val packageName: String,
     val classSimpleName: String,
+    val exportedClassSimpleName: String,
     val isOpen: Boolean,
     val isThrowable: Boolean,
     val concreteTypeParameters: List<TypeParameterDescriptor>,

--- a/compiler/src/main/kotlin/deezer/kustom/compiler/js/mapping/CustomMapping.kt
+++ b/compiler/src/main/kotlin/deezer/kustom/compiler/js/mapping/CustomMapping.kt
@@ -199,6 +199,13 @@ fun initCustomMapping() {
             importMethod = { targetName, typeName, concreteTypeParameters ->
                 val lambda = typeName as ParameterizedTypeName
                 val returnType = lambda.typeArguments.last()
+
+                if (lambda.typeArguments.size == 1) {
+                    return@MappingOutput "{ ".toFormatString() +
+                        returnType.cached(concreteTypeParameters).importedMethod(targetName + "()") +
+                        "}"
+                }
+
                 val namedArgs = lambda.typeArguments.dropLast(1)
                     .mapIndexed { index, tn -> tn to shortNamesForIndex(index) }
 
@@ -221,6 +228,12 @@ fun initCustomMapping() {
             exportMethod = { targetName, typeName, concreteTypeParameters ->
                 val lambda = typeName as ParameterizedTypeName
                 val returnType = lambda.typeArguments.last()
+
+                if (lambda.typeArguments.size == 1) {
+                    return@MappingOutput "{ ".toFormatString() +
+                        returnType.cached(concreteTypeParameters).exportedMethod(targetName + "()") +
+                        "}"
+                }
                 val namedArgs = lambda.typeArguments.dropLast(1)
                     .mapIndexed { index, tn -> tn to shortNamesForIndex(index) }
 

--- a/compiler/src/main/kotlin/deezer/kustom/compiler/js/pattern/ClassDeclarationParser.kt
+++ b/compiler/src/main/kotlin/deezer/kustom/compiler/js/pattern/ClassDeclarationParser.kt
@@ -50,7 +50,8 @@ import deezer.kustom.compiler.js.mapping.OriginTypeName
 @KotlinPoetKspPreview
 fun parseClass(
     classDeclaration: KSClassDeclaration,
-    forcedConcreteTypeParameters: List<Pair<String, TypeName>>? = null
+    forcedConcreteTypeParameters: List<Pair<String, TypeName>>? = null,
+    exportedClassSimpleName: String
 ): Descriptor? {
     val typeParamResolver = classDeclaration.typeParameters.toTypeParameterResolver()
 
@@ -117,6 +118,7 @@ fun parseClass(
             InterfaceDescriptor(
                 packageName = packageName,
                 classSimpleName = classSimpleName,
+                exportedClassSimpleName = exportedClassSimpleName,
                 concreteTypeParameters = concreteTypeParameters,
                 supers = superTypes,
                 properties = properties,
@@ -144,6 +146,7 @@ fun parseClass(
         classKind == ClassKind.CLASS -> ClassDescriptor(
             packageName = packageName,
             classSimpleName = classSimpleName,
+            exportedClassSimpleName = exportedClassSimpleName,
             isOpen = isOpen,
             isThrowable = classDeclaration.isThrowable(),
             concreteTypeParameters = concreteTypeParameters,
@@ -181,7 +184,7 @@ private val nonExportableFunctions = listOf(
     "addSuppressed",
     "getSuppressed",
 
-) + (1..30).map { "component$it" }
+    ) + (1..30).map { "component$it" }
 
 @OptIn(KotlinPoetKspPreview::class)
 fun KSClassDeclaration.parseFunctions(

--- a/compiler/src/main/kotlin/deezer/kustom/compiler/js/pattern/ClassDeclarationParser.kt
+++ b/compiler/src/main/kotlin/deezer/kustom/compiler/js/pattern/ClassDeclarationParser.kt
@@ -143,11 +143,12 @@ fun parseClass(
                 subClasses = sealedSubClasses,
             )
         }
-        classKind == ClassKind.CLASS -> ClassDescriptor(
+        classKind == ClassKind.CLASS || classKind == ClassKind.OBJECT -> ClassDescriptor(
             packageName = packageName,
             classSimpleName = classSimpleName,
             exportedClassSimpleName = exportedClassSimpleName,
             isOpen = isOpen,
+            isObject = classKind == ClassKind.OBJECT,
             isThrowable = classDeclaration.isThrowable(),
             concreteTypeParameters = concreteTypeParameters,
             supers = superTypes,

--- a/compiler/src/main/kotlin/deezer/kustom/compiler/js/pattern/KotlinPoetExt.kt
+++ b/compiler/src/main/kotlin/deezer/kustom/compiler/js/pattern/KotlinPoetExt.kt
@@ -32,6 +32,7 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.ksp.KotlinPoetKspPreview
 import com.squareup.kotlinpoet.ksp.TypeParameterResolver
 import com.squareup.kotlinpoet.ksp.toTypeName
+import deezer.kustom.compiler.GenericsVisitor
 import deezer.kustom.compiler.Logger
 import deezer.kustom.compiler.js.mapping.isParameterizedAllowed
 import java.io.File
@@ -46,6 +47,7 @@ fun TypeName.asClassName(): ClassName =
 
 fun TypeName.removeTypeParameter(): TypeName =
     if (this is ParameterizedTypeName && !isParameterizedAllowed()) {
+    //GenericsVisitor.resolvedGenerics
         rawType.copy(this.isNullable)
     } else this
 

--- a/compiler/src/main/kotlin/deezer/kustom/compiler/js/pattern/class/ClassTransformer.kt
+++ b/compiler/src/main/kotlin/deezer/kustom/compiler/js/pattern/class/ClassTransformer.kt
@@ -22,15 +22,17 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.STRING
+import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
-import deezer.kustom.compiler.Logger
 import deezer.kustom.compiler.js.ALL_KOTLIN_EXCEPTIONS
 import deezer.kustom.compiler.js.ClassDescriptor
 import deezer.kustom.compiler.js.FormatString
 import deezer.kustom.compiler.js.MethodNameDisambiguation
+import deezer.kustom.compiler.js.ParameterDescriptor
 import deezer.kustom.compiler.js.dynamicCastTo
 import deezer.kustom.compiler.js.dynamicNotString
 import deezer.kustom.compiler.js.dynamicNull
@@ -71,155 +73,170 @@ fun transformClass(origin: ClassDescriptor): FileSpec {
     // Due to that limitation, when class is open, we need to define a "random" name to avoid conflicts.
     val commonFieldName = if (origin.isOpen) "common_" + origin.classIdHash else "common"
 
-    return FileSpec.builder(jsClassPackage, origin.exportedClassSimpleName)
+    val fileBuilder = FileSpec.builder(jsClassPackage, origin.exportedClassSimpleName)
         .addAliasedImport(origin.asClassName, "Common${origin.classSimpleName}")
-        .addType(
-            TypeSpec.classBuilder(origin.exportedClassSimpleName)
-                .addAnnotation(jsExport)
-                .addModifiers(if (origin.isOpen) listOf(KModifier.OPEN) else emptyList())
-                .primaryConstructor(
-                    /**
-                     * Primary constructor have to contain the commonMain instance,
-                     * but it cannot be exported
-                     */
-                    FunSpec.constructorBuilder()
-                        .also { b ->
-                            origin.constructorParams.forEach {
-                                b.addParameter(ParameterSpec(it.name, it.type.exportedTypeName))
-                            }
-                        }
-                        .build()
-                )
-                .addFunction(
-                    FunSpec.constructorBuilder()
-                        //TODO: Annotation could be added only when there is 1+ params in ctor, else it's useless
-                        .suppress("UNNECESSARY_SAFE_CALL")
-                        .addModifiers(KModifier.INTERNAL)
-                        .callThisConstructor(
-                            CodeBlock.of(
-                                // The '?' is actually required by Typescript (Kotlin 1.6.0).
-                                // Without that, it fails at runtime because there is no dynamicCastTo method on null.
-                                // > TypeError: Cannot read properties of null (reading 'dynamicCastTo')
-                                origin.constructorParams
-                                    .joinToString { "${it.name}·=·%M${if (ctorDyn == dynamicNull) "?" else ""}.%M<%T>()" },
-                                *origin.constructorParams
-                                    .flatMap { listOf(ctorDyn, dynamicCastTo, it.type.exportedTypeName) }.toTypedArray()
-                            )
-                        )
-                        .addParameter(ParameterSpec("common", originalClass))
-                        .addStatement("this.$commonFieldName = common")
-                        .build()
-                )
-                .addProperty(
-                    PropertySpec.builder(commonFieldName, originalClass, KModifier.INTERNAL)
-                        .also { if (origin.constructorParams.isNotEmpty()) it.addModifiers(KModifier.LATEINIT) }
-                        .mutable(true) // because lateinit
-                        .build()
-                )
-                .also { b ->
-                    if (firstCtorParam == null) {
-                        b.addInitializerBlock(CodeBlock.of("$commonFieldName = Common${origin.classSimpleName}()\n"))
-                    } else {
-                        var fs = FormatString("if (${firstCtorParam.name} != %M) {\n", ctorDyn)
-                        fs += FormatString("${INDENTATION}$commonFieldName = %T(\n", origin.asClassName)
-                        origin.constructorParams.forEach {
-                            fs += "$INDENTATION$INDENTATION${it.name}·=·"
-                            fs += it.importedMethod
-                            fs += ",\n"
-                        }
-                        fs += "$INDENTATION)\n"
-                        fs += "}\n"
-                        b.addInitializerBlock(fs.asCode())
-                    }
-                }
-                .also { b ->
-                    origin.supers.forEach { supr ->
-                        if (supr.parameters == null) {
-                            b.addSuperinterface(supr.origin.exportedTypeName)
-                        } else {
-                            // sealed and exceptions are not wrapped as the other classes
-                            if (supr.isSealed || supr.origin.concreteTypeName in ALL_KOTLIN_EXCEPTIONS) {
-                                b.superclass(supr.origin.exportedTypeName)
-                                b.addSuperclassConstructorParameter(
-                                    CodeBlock.of(supr.parameters.joinToString { it.name + " = " + it.name })
-                                )
-                            } else {
-                                // other wrappers have an additional constructor by us, we can trick to avoid RAM usage
-                                b.superclass(supr.origin.exportedTypeName)
-                                b.addSuperclassConstructorParameter(
-                                    CodeBlock.of(
-                                        "common = %M.%M<%T>()",
-                                        dynamicNull, dynamicCastTo, supr.origin.concreteTypeName.asClassName()
-                                    )
-                                )
-                            }
-                        }
-                    }
-                }
-                .also { b ->
-                    origin.properties
-                        // Don't export fields only present in super implementation
-                        // .filterNot { p -> origin.supers.any { s -> s.parameters?.any { it.name == p.name } ?: false } }
-                        .forEach {
-                            b.addProperty(
-                                overrideGetterSetter(
-                                    it,
-                                    commonFieldName,
-                                    import = false,
-                                    forceOverride = false,
-                                    isClassOpen = origin.isOpen,
-                                    isClassThrowable = origin.isThrowable
-                                )
-                            )
-                        }
-                }
-                .also { b ->
-                    val mnd = MethodNameDisambiguation()
-                    origin.functions.forEach { func ->
-                        b.addFunction(
-                            func.buildWrappingFunction(
-                                body = true,
-                                import = false,
-                                delegateName = commonFieldName,
-                                mnd = mnd,
-                                isClassOpen = origin.isOpen
-                            )
-                        )
-                    }
-                }
-                .also { b ->
-                    if (origin.isThrowable) {
-                        b.addFunction(
-                            FunSpec.builder("import")
-                                .suppress("NON_EXPORTABLE_TYPE")
-                                .also { if (origin.isOpen) it.addModifiers(KModifier.OPEN) }
-                                .addModifiers(KModifier.OVERRIDE)
-                                .returns(originalClass)
-                                .addStatement("return·this.$commonFieldName")
-                                .build()
-                        )
-                    }
-                }
-                .build()
-        )
-        .addFunction(
+        .addType(buildExportedClass(origin, ctorDyn, originalClass, commonFieldName, firstCtorParam))
+    if (!origin.isObject) {
+        fileBuilder.addFunction(
             FunSpec.builder("export${origin.exportedClassSimpleName}")
                 .receiver(originalClass)
                 .returns(jsExportedClass)
                 .addStatement("return·%T(this)", jsExportedClass)
                 .build()
         )
-        .also { b ->
-            //if (!origin.isThrowable) { // Required by sealed class for now, to be improved
-            b.addFunction(
-                FunSpec.builder("import${origin.exportedClassSimpleName}")
-                    .receiver(jsExportedClass)
-                    .returns(originalClass)
-                    .addStatement("return·this.$commonFieldName")
-                    .build()
-            )
-            //}
-        }
+
+        //if (!origin.isThrowable) { // Required by sealed class for now, to be improved
+        fileBuilder.addFunction(
+            FunSpec.builder("import${origin.exportedClassSimpleName}")
+                .receiver(jsExportedClass)
+                .returns(originalClass)
+                .addStatement("return·this.$commonFieldName")
+                .build()
+        )
+    }
+    return fileBuilder
         .indent(INDENTATION)
         .build()
+}
+
+private fun buildExportedClass(
+    origin: ClassDescriptor,
+    ctorDyn: MemberName?,
+    originalClass: TypeName,
+    commonFieldName: String,
+    firstCtorParam: ParameterDescriptor?,
+): TypeSpec {
+    val builder = if (origin.isObject) TypeSpec.objectBuilder(origin.exportedClassSimpleName)
+    else TypeSpec.classBuilder(origin.exportedClassSimpleName)
+    builder.addAnnotation(jsExport)
+        .addModifiers(if (origin.isOpen) listOf(KModifier.OPEN) else emptyList())
+    if (!origin.isObject) {
+        builder
+            .primaryConstructor(
+                /**
+                 * Primary constructor have to contain the commonMain instance,
+                 * but it cannot be exported
+                 */
+                /**
+                 * Primary constructor have to contain the commonMain instance,
+                 * but it cannot be exported
+                 */
+                FunSpec.constructorBuilder()
+                    .also { b ->
+                        origin.constructorParams.forEach {
+                            b.addParameter(ParameterSpec(it.name, it.type.exportedTypeName))
+                        }
+                    }
+                    .build()
+            )
+            .addFunction(
+                FunSpec.constructorBuilder()
+                    //TODO: Annotation could be added only when there is 1+ params in ctor, else it's useless
+                    .suppress("UNNECESSARY_SAFE_CALL")
+                    .addModifiers(KModifier.INTERNAL)
+                    .callThisConstructor(
+                        CodeBlock.of(
+                            // The '?' is actually required by Typescript (Kotlin 1.6.0).
+                            // Without that, it fails at runtime because there is no dynamicCastTo method on null.
+                            // > TypeError: Cannot read properties of null (reading 'dynamicCastTo')
+                            origin.constructorParams
+                                .joinToString { "${it.name}·=·%M${if (ctorDyn == dynamicNull) "?" else ""}.%M<%T>()" },
+                            *origin.constructorParams
+                                .flatMap { listOf(ctorDyn, dynamicCastTo, it.type.exportedTypeName) }.toTypedArray()
+                        )
+                    )
+                    .addParameter(ParameterSpec("common", originalClass))
+                    .addStatement("this.$commonFieldName = common")
+                    .build()
+            )
+            .addProperty(
+                PropertySpec.builder(commonFieldName, originalClass, KModifier.INTERNAL)
+                    .also { if (origin.constructorParams.isNotEmpty()) it.addModifiers(KModifier.LATEINIT) }
+                    .mutable(true) // because lateinit
+                    .build()
+            )
+            .also { b ->
+                if (firstCtorParam == null) {
+                    b.addInitializerBlock(CodeBlock.of("$commonFieldName = Common${origin.classSimpleName}()\n"))
+                } else {
+                    var fs = FormatString("if (${firstCtorParam.name} != %M) {\n", ctorDyn)
+                    fs += FormatString("${INDENTATION}$commonFieldName = %T(\n", origin.asClassName)
+                    origin.constructorParams.forEach {
+                        fs += "$INDENTATION$INDENTATION${it.name}·=·"
+                        fs += it.importedMethod
+                        fs += ",\n"
+                    }
+                    fs += "$INDENTATION)\n"
+                    fs += "}\n"
+                    b.addInitializerBlock(fs.asCode())
+                }
+            }
+            .also { b ->
+                origin.supers.forEach { supr ->
+                    if (supr.parameters == null) {
+                        b.addSuperinterface(supr.origin.exportedTypeName)
+                    } else {
+                        // sealed and exceptions are not wrapped as the other classes
+                        if (supr.isSealed || supr.origin.concreteTypeName in ALL_KOTLIN_EXCEPTIONS) {
+                            b.superclass(supr.origin.exportedTypeName)
+                            b.addSuperclassConstructorParameter(
+                                CodeBlock.of(supr.parameters.joinToString { it.name + " = " + it.name })
+                            )
+                        } else {
+                            // other wrappers have an additional constructor by us, we can trick to avoid RAM usage
+                            b.superclass(supr.origin.exportedTypeName)
+                            b.addSuperclassConstructorParameter(
+                                CodeBlock.of(
+                                    "common = %M.%M<%T>()",
+                                    dynamicNull, dynamicCastTo, supr.origin.concreteTypeName.asClassName()
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+    }
+
+    origin.properties
+        // Don't export fields only present in super implementation
+        // .filterNot { p -> origin.supers.any { s -> s.parameters?.any { it.name == p.name } ?: false } }
+        .forEach {
+            builder.addProperty(
+                overrideGetterSetter(
+                    prop = it,
+                    target = if (origin.isObject) "Common${origin.classSimpleName}" else commonFieldName,
+                    import = false,
+                    forceOverride = false,
+                    isClassOpen = origin.isOpen,
+                    isClassThrowable = origin.isThrowable
+                )
+            )
+        }
+
+    val mnd = MethodNameDisambiguation()
+    origin.functions.forEach { func ->
+        builder.addFunction(
+            func.buildWrappingFunction(
+                body = true,
+                import = false,
+                delegateName = if (origin.isObject) "Common${origin.classSimpleName}" else commonFieldName,
+                mnd = mnd,
+                isClassOpen = origin.isOpen
+            )
+        )
+    }
+
+    if (origin.isThrowable) {
+        builder.addFunction(
+            FunSpec.builder("import")
+                .suppress("NON_EXPORTABLE_TYPE")
+                .also { if (origin.isOpen) it.addModifiers(KModifier.OPEN) }
+                .addModifiers(KModifier.OVERRIDE)
+                .returns(originalClass)
+                .addStatement("return·this.$commonFieldName")
+                .build()
+        )
+    }
+
+    return builder.build()
 }

--- a/lib/src/commonMain/kotlin/deezer/kustom/KustomExport.kt
+++ b/lib/src/commonMain/kotlin/deezer/kustom/KustomExport.kt
@@ -44,7 +44,7 @@ public annotation class KustomExportGenerics(
 
 @Target() // No target, only there for data container
 public annotation class KustomGenerics(
-    public val name: String,
+    public val name: String = "",
     public val kClass: KClass<*>,
     public val typeParameters: Array<KClass<*>>,
 )

--- a/lib/src/commonMain/kotlin/deezer/kustom/KustomExport.kt
+++ b/lib/src/commonMain/kotlin/deezer/kustom/KustomExport.kt
@@ -44,7 +44,7 @@ public annotation class KustomExportGenerics(
 
 @Target() // No target, only there for data container
 public annotation class KustomGenerics(
-    public val name: String = "",
     public val kClass: KClass<*>,
     public val typeParameters: Array<KClass<*>>,
+    public val name: String = "",
 )

--- a/samples/src/commonMain/kotlin/sample/_class/simple/SimpleClass.kt
+++ b/samples/src/commonMain/kotlin/sample/_class/simple/SimpleClass.kt
@@ -5,4 +5,5 @@ import deezer.kustom.KustomExport
 @KustomExport
 class SimpleClass {
     val simpleValue: Int = 42
+    fun foo(act: () -> Unit) = act()
 }

--- a/samples/src/commonMain/kotlin/sample/_class/static/Statics.kt
+++ b/samples/src/commonMain/kotlin/sample/_class/static/Statics.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Deezer.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+@file:KustomExportGenerics(
+    exportGenerics = [
+        //KustomGenerics(StaticGenericFactory::class, arrayOf(Long::class)),
+    ]
+)
+
+package sample._class.static
+
+import deezer.kustom.KustomExport
+import deezer.kustom.KustomExportGenerics
+import sample.generics.GenericsImpl
+
+fun createString() = "string from factory method"
+
+@KustomExport
+object StaticFactory {
+    fun create(stuff: Long) = "string from factory object stuff=$stuff"
+}
+
+object StaticGenericFactory {
+    fun <T> create(): GenericsImpl<T> {
+        return GenericsImpl<T>()
+    }
+}

--- a/samples/src/commonMain/kotlin/sample/_class/static/Statics.ts
+++ b/samples/src/commonMain/kotlin/sample/_class/static/Statics.ts
@@ -1,0 +1,8 @@
+import { runTest } from "../../shared_ts/RunTest"
+import { assert, assertEquals } from "../../shared_ts/Assert"
+import { sample } from '@kustom/Samples'
+
+runTest("Statics", () : void => {
+    var str = sample._class.static.js.StaticFactory.create(44)
+    assertEquals(str, "string from factory object stuff=44", "static factory can be used")
+})

--- a/samples/src/commonMain/kotlin/sample/generics/Generics.kt
+++ b/samples/src/commonMain/kotlin/sample/generics/Generics.kt
@@ -17,8 +17,12 @@
 
 @file:KustomExportGenerics(
     exportGenerics = [
-        KustomGenerics("NameNotHonoredYet", GenericsStuff::class, arrayOf(Long::class)),
-        KustomGenerics("NameNotHonoredYet", GenericsInterface::class, arrayOf(Long::class)),
+        KustomGenerics("GenericsStuff", GenericsStuff::class, arrayOf(Long::class)),
+        KustomGenerics("GenericsStuffFloat", GenericsStuff::class, arrayOf(Float::class)),
+        KustomGenerics("GenericsInterface", GenericsInterface::class, arrayOf(Long::class)),
+        KustomGenerics("GenericsInterfaceFloat", GenericsInterface::class, arrayOf(Float::class)),
+        KustomGenerics("GenericsImpl", GenericsImpl::class, arrayOf(Long::class)),
+        KustomGenerics("GenericsImplFloat", GenericsImpl::class, arrayOf(Float::class)),
     ]
 )
 
@@ -44,22 +48,26 @@ interface GenericsInterface<Template> {
     fun baz() = DataClass("baz data")
 }
 
-// Concrete classes with generics cannot be generated without failing the compilation
-// TODO: https://github.com/google/ksp/issues/731
-/*
-class GenericsInterfaceDefault<T> : GenericsInterface<T> {
-    override fun addListener(listener: (Long, T) -> Unit, default: T) {
-        listener(33, default)
-    }
+class GenericsImpl<Template> {
+    var bar: Template? = null
 }
- */
+
+@KustomExport
+class GenericsFactory {
+    fun buildCLong(value: Long) = GenericsImpl<Long>().apply { bar = value }
+    fun buildCFloat(value: Float) = GenericsImpl<Float>().apply { bar = value }
+}
 
 @KustomExport
 class GenericsConsumer {
-    fun consume(typeAlias: GenericsInterface<Long>) =
-        "consumed " + typeAlias.fooBar(123L) + " / " + typeAlias.fooBars(listOf(1, 2, 3))
+    fun consumeILong(generic: GenericsInterface<Long>) =
+        "consumed " + generic.fooBar(123L) + " / " + generic.fooBars(listOf(1, 2, 3))
 
-    fun create(): GenericsInterface<Long> = TODO()//TypeAliasInterfaceDefault()
+    fun consumeIFloat(generic: GenericsInterface<Float>) =
+        "consumed " + generic.fooBar(123f) + " / " + generic.fooBars(listOf(1.1f, 2.2f, 3.3f))
+
+    fun consumeCLong(generic: GenericsImpl<Long>) = "consumed " + generic.bar
+    fun consumeCFloat(generic: GenericsImpl<Float>) = "consumed " + generic.bar
 }
 
 // Trick to export interface with generics type: specific typealias!

--- a/samples/src/commonMain/kotlin/sample/generics/Generics.kt
+++ b/samples/src/commonMain/kotlin/sample/generics/Generics.kt
@@ -17,12 +17,12 @@
 
 @file:KustomExportGenerics(
     exportGenerics = [
-        KustomGenerics("GenericsStuff", GenericsStuff::class, arrayOf(Long::class)),
-        KustomGenerics("GenericsStuffFloat", GenericsStuff::class, arrayOf(Float::class)),
-        KustomGenerics("GenericsInterface", GenericsInterface::class, arrayOf(Long::class)),
-        KustomGenerics("GenericsInterfaceFloat", GenericsInterface::class, arrayOf(Float::class)),
-        KustomGenerics("GenericsImpl", GenericsImpl::class, arrayOf(Long::class)),
-        KustomGenerics("GenericsImplFloat", GenericsImpl::class, arrayOf(Float::class)),
+        KustomGenerics(GenericsStuff::class, arrayOf(Long::class)),
+        KustomGenerics(GenericsStuff::class, arrayOf(Float::class), "GenericsStuffFloat"),
+        KustomGenerics(GenericsInterface::class, arrayOf(Long::class), "GenericsInterface"),
+        KustomGenerics(GenericsInterface::class, arrayOf(Float::class), "GenericsInterfaceFloat"),
+        KustomGenerics(GenericsImpl::class, arrayOf(Long::class), "GenericsImpl"),
+        KustomGenerics(GenericsImpl::class, arrayOf(Float::class), "GenericsImplFloat"),
     ]
 )
 

--- a/samples/src/commonMain/kotlin/sample/generics/Generics.ts
+++ b/samples/src/commonMain/kotlin/sample/generics/Generics.ts
@@ -18,9 +18,32 @@ runTest("Generics", () : void => {
             return new sample._class.data.js.DataClass("4", 4)
         }
     }
-    var impl = new CustomImpl()
+
+    class CustomImplFloat implements sample.generics.js.GenericsInterfaceFloat {
+        bar: Nullable<number>
+        addListener(listener: (p0: number, p1: number) => void, _default: number): void {
+            throw new Error("Method not implemented.")
+        }
+        fooBar(input: number): string {
+            return "custom " + (input + 2)
+        }
+        fooBars(inputs: Array<number>): string {
+            return "customs " + inputs.join()
+        }
+        baz() : sample._class.data.js.DataClass {
+            return new sample._class.data.js.DataClass("4", 4)
+        }
+    }
+
+    var implLong = new CustomImpl()
+    var implFloat = new CustomImplFloat()
     var consumer = new sample.generics.js.GenericsConsumer()
-    assertEquals("consumed custom 125 / customs 1,2,3", consumer.consume(impl), "generics interface re-typed via TypeAlias")
+    var factory = new sample.generics.js.GenericsFactory()
+    assertEquals("consumed custom 125 / customs 1,2,3", consumer.consumeILong(implLong), "generics interface re-typed")
+    assertEquals("consumed custom 125 / customs 1,2,3", consumer.consumeILong(implFloat), "generics interface re-typed") // Same because Float & Long are exported as numbers
+    assertEquals("consumed 22", consumer.consumeCLong(factory.buildCLong(22.11)), "generics interface re-typed")
+    assertEquals("consumed 33.55", consumer.consumeCFloat(factory.buildCFloat(33.55)), "generics interface re-typed")
+    //assertEquals("consumed custom 125 / customs 1,2,3", consumer.consumeCLong(), "generics interface re-typed via TypeAlias")
 
     // TODO: https://github.com/google/ksp/issues/731
     //var defaultImpl = new sample.generics.js.TypeAliasInterfaceDefault()


### PR DESCRIPTION
```
@file:KustomExportGenerics(
    exportGenerics = [
        KustomGenerics(GenericsStuff::class, arrayOf(Long::class)),
        KustomGenerics(GenericsStuff::class, arrayOf(Float::class), "GenericsStuffFloat"),
])
```
By default a "forced" type is applied and re-use the class name, so the first configuration will generate a wrapper named "GenericStuff" in the ".js" package (or without package if packageErasure=true). Now you can also define a name to export a second type. Every annotated classes in this build module will be aware of the new name and will replace `GenericsStuff<Float>` by `GenericsStuffFloat`

### Bonus: objects exported
You can now annotate a `object MyFactory` with @KustomExport.
