### PR TITLE
Add SimulatorArm64 target for tvOS and watchOS

### DIFF
--- a/lib-coroutines/build.gradle.kts
+++ b/lib-coroutines/build.gradle.kts
@@ -10,7 +10,9 @@ kotlin {
     ios()
     iosSimulatorArm64()
     tvos()
+    tvosSimulatorArm64()
     watchos()
+    watchosSimulatorArm64()
 
     sourceSets {
         all {
@@ -23,6 +25,10 @@ kotlin {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1")
             }
         }
+        val tvosMain by getting
+        val tvosSimulatorArm64Main by getting { dependsOn(tvosMain)}
+        val watchosMain by getting
+        val watchosSimulatorArm64Main by getting { dependsOn(watchosMain)}
     }
 
     targets.all {

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -10,13 +10,19 @@ kotlin {
     ios()
     iosSimulatorArm64()
     tvos()
+    tvosSimulatorArm64()
     watchos()
+    watchosSimulatorArm64()
 
     sourceSets {
         all {
             languageSettings.optIn("kotlin.RequiresOptIn")
             languageSettings.optIn("kotlin.js.ExperimentalJsExport")
         }
+        val tvosMain by getting
+        val tvosSimulatorArm64Main by getting { dependsOn(tvosMain)}
+        val watchosMain by getting
+        val watchosSimulatorArm64Main by getting { dependsOn(watchosMain)}
     }
 
     targets.all {


### PR DESCRIPTION
KustomExport target `tvos()` and `watchos()` which does not include the support of the Arm64 simulator. 
Here is a PR to add those targets.