### PR TITLE
Handle an interface with suspend that returns a JS friendly type

### DIFF
--- a/compiler/src/main/kotlin/deezer/kustomexport/compiler/js/pattern/SharedTransformer.kt
+++ b/compiler/src/main/kotlin/deezer/kustomexport/compiler/js/pattern/SharedTransformer.kt
@@ -141,11 +141,12 @@ fun FunctionDescriptor.buildWrappingFunctionBody(
     body += "val result = $callStr("
     body += if (parameters.isNotEmpty()) "\n" else ""
     body += params
-    body += if (parameters.isNotEmpty()) ")\n" else ")\n"
+    body += if (parameters.isNotEmpty()) ")" else ")"
+
+    body += if (import && isSuspend) ".%M()\n".toFormatString(coroutinesAwait) else "\n".toFormatString()
 
     body += if (import || !isSuspend) "return·" else ""
     body += returnType.portMethod(import, "result".toFormatString())
-    body += if (import && isSuspend) ".%M()".toFormatString(coroutinesAwait) else "".toFormatString()
 
     if (!import && isSuspend) body += "\n}"
     return body

--- a/samples/src/commonMain/kotlin/sample/coroutines/InterfaceWithSuspend.kt
+++ b/samples/src/commonMain/kotlin/sample/coroutines/InterfaceWithSuspend.kt
@@ -1,0 +1,21 @@
+package sample.coroutines
+
+import deezer.kustomexport.KustomExport
+
+@KustomExport
+interface IThingDoer {
+    suspend fun doThings(): List<Long>
+}
+
+class NonWebThingDoer : IThingDoer {
+    override suspend fun doThings(): List<Long> {
+        return listOf(1, 2, 3)
+    }
+}
+
+@KustomExport
+class WebThingDoer : IThingDoer {
+    override suspend fun doThings(): List<Long> {
+        return listOf(3, 2, 1)
+    }
+}

--- a/samples/src/commonMain/kotlin/sample/coroutines/InterfaceWithSuspend.ts
+++ b/samples/src/commonMain/kotlin/sample/coroutines/InterfaceWithSuspend.ts
@@ -1,0 +1,12 @@
+import { runTest } from "../shared_ts/RunTest"
+import { assert, assertEquals, assertQuiet, assertEqualsQuiet } from "../shared_ts/Assert"
+import { sample } from '@kustom/Samples'
+
+runTest("InterfaceWithSuspend", async () : Promise<void> => {
+    var neverAbortController = new AbortController()
+    var neverAbortSignal = neverAbortController.signal
+
+    const thingDoer = new sample.coroutines.js.WebThingDoer()
+    const res = await thingDoer.doThings(neverAbortSignal)
+    assertEquals([3, 2, 1].join(","), res.join(","), "executes suspend function with JS friendly types")
+})


### PR DESCRIPTION
If we have an interface that contains a `suspend` that returns a type that would get converted back and forth for JS (`Long <-> Double`), I noticed it tries to cast the type (`.toLong()`) before the promise is awaited.

An example:
```kt
@KustomExport
interface Thing {
    suspend fun getThing(): Long
}

class NonJSThing : Thing {
    override suspend fun getThing(): Long {
        return 1
    }
}

@KustomExport
class JSThing : Thing {
    override suspend fun getThing(): Long {
        return 1
    }
}
```

would generate the following code:
```kt
private class ImportedThing(
    internal val exported: Thing,
) : CommonThing {
    public override suspend fun getThing(): Long {
        val abortController = AbortController()
        val abortSignal = abortController.signal
        coroutineContext.job.invokeOnCompletion { abortController.abort() }
        val result = exported.getThing(    abortSignal = abortSignal)
        // It is casting the result to long before the promise has been awaited
        return result.toLong().await()
    }
}
```

with this change it now generates:
```kt
private class ImportedThing(
    internal val exported: Thing,
) : CommonThing {
    public override suspend fun getThing(): Long {
        val abortController = AbortController()
        val abortSignal = abortController.signal
        coroutineContext.job.invokeOnCompletion { abortController.abort() }
        val result = exported.getThing(    abortSignal = abortSignal).await()
        // The result has awaited the promise to resolve and is now a Double to be casted toLong()
        return result.toLong()
    }
}
```
