### PR TITLE
Avoid erasing types and delegate to js export

### DIFF
--- a/compiler/src/main/kotlin/deezer/kustomexport/compiler/js/mapping/TypeMapping.kt
+++ b/compiler/src/main/kotlin/deezer/kustomexport/compiler/js/mapping/TypeMapping.kt
@@ -47,7 +47,7 @@ class OriginTypeName(
     val exportedTypeName: TypeName by lazy {
         // Remove TypeParameter: because we can't export generic in a cool manner yet, so we produce concrete from generics.
         // See @KustomExportGenerics
-        exportedType().removeTypeParameter()
+        exportedType()
     }
 
     fun exportedMethod(name: FormatString) = exportMethod(name)

--- a/compiler/src/main/kotlin/deezer/kustomexport/compiler/js/mapping/TypeMapping.kt
+++ b/compiler/src/main/kotlin/deezer/kustomexport/compiler/js/mapping/TypeMapping.kt
@@ -45,9 +45,13 @@ class OriginTypeName(
     fun importedMethod(name: FormatString) = importMethod(name)
 
     val exportedTypeName: TypeName by lazy {
-        // Remove TypeParameter: because we can't export generic in a cool manner yet, so we produce concrete from generics.
-        // See @KustomExportGenerics
-        exportedType()
+        var type = exportedType()
+        if(isKustomExportAnnotated) {
+            // Remove TypeParameter: because we can't export generic in a cool manner yet, so we produce concrete from generics.
+            // See @KustomExportGenerics
+            type = type.removeTypeParameter()
+        }
+        type
     }
 
     fun exportedMethod(name: FormatString) = exportMethod(name)

--- a/compiler/src/test/kotlin/deezer/kustomexport/compiler/TypeMappingTest.kt
+++ b/compiler/src/test/kotlin/deezer/kustomexport/compiler/TypeMappingTest.kt
@@ -186,6 +186,58 @@ class TypeMappingTest {
     }
 
     @Test
+    fun maps() {
+        assertCompilationOutput(
+            """
+            package foo.bar
+            import deezer.kustomexport.KustomExport
+
+            @KustomExport
+            class ClassWithMaps {
+                var myMap: Map<String, Int>
+            }
+    """,
+            ExpectedOutputFile(
+                path = "foo/bar/js/ClassWithMaps.kt",
+                content = """
+                package foo.bar.js
+                
+                import kotlin.Int
+                import kotlin.String
+                import kotlin.Suppress
+                import kotlin.collections.Map
+                import kotlin.js.JsExport
+                import foo.bar.ClassWithMaps as CommonClassWithMaps
+                
+                @JsExport
+                public class ClassWithMaps() {
+                    internal var common: CommonClassWithMaps
+                
+                    init {
+                        common = CommonClassWithMaps()
+                    }
+                
+                    public var myMap: Map<String, Int>
+                        get() = common.myMap
+                        set(setValue) {
+                            common.myMap = setValue
+                        }
+                
+                    @Suppress("UNNECESSARY_SAFE_CALL")
+                    internal constructor(common: CommonClassWithMaps) : this() {
+                        this.common = common
+                    }
+                }
+                
+                public fun CommonClassWithMaps.exportClassWithMaps(): ClassWithMaps = ClassWithMaps(this)
+                
+                public fun ClassWithMaps.importClassWithMaps(): CommonClassWithMaps = this.common
+                """.trimIndent()
+            )
+        )
+    }
+
+    @Test
     fun from_Long_to_Double() {
         assertCompilationOutput(
             """

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 kotlin.mpp.stability.nowarn=true
-kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
 
 kotlinVersion=1.7.22

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 kotlin.mpp.stability.nowarn=true
-kotlin.native.enableDependencyPropagation=false
 
 kotlinVersion=1.7.22
 kspVersion=1.7.22-1.0.8


### PR DESCRIPTION
This patch will relax the current were the types where erased leading to cases where the generated code won't compile.

Example if you have `map: Map<String, Int>` the ksp generated code will result in: `map: Map` this is not ideal because even if the type `map: Map<String, Int>` will be expose as an `any` this will still compile and the code is usable anyway.

This fixes issues:

https://github.com/deezer/KustomExport/issues/35
https://github.com/deezer/KustomExport/issues/29